### PR TITLE
Updating 3rd party dependencies and fixes

### DIFF
--- a/generator/pom.xml
+++ b/generator/pom.xml
@@ -3,12 +3,12 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>net.java.dev.msv</groupId>
   <artifactId>msv-generator</artifactId>
-  <version>2011.2-SNAPSHOT</version>
+  <version>2017.1-SNAPSHOT</version>
   <name>MSV Generator</name>
   <parent>
       <groupId>net.java.dev.msv</groupId>
       <artifactId>msv</artifactId>
-      <version>2011.2-SNAPSHOT</version>
+      <version>2017.1-SNAPSHOT</version>
   </parent>
 
   <scm>
@@ -64,7 +64,7 @@
     <dependency>
         <groupId>xerces</groupId>
         <artifactId>xercesImpl</artifactId>
-        <version>2.9.1</version>
+        <version>2.11.0</version>
         <optional>true</optional>
     </dependency>
     <dependency><!-- for tests -->

--- a/msv/pom.xml
+++ b/msv/pom.xml
@@ -34,14 +34,14 @@ EVEN IF SUN HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
     <modelVersion>4.0.0</modelVersion>
     <groupId>net.java.dev.msv</groupId>
     <artifactId>msv-core</artifactId>
-    <version>2011.2-SNAPSHOT</version>
+    <version>2017.1-SNAPSHOT</version>
     <name>MSV Core</name>
     <description>Multi-Schema Validator Core package</description>
-    <packaging>bundle</packaging>
+    <packaging>jar</packaging><!-- OSGi bundle is missing activator interface -->
     <parent>
       <groupId>net.java.dev.msv</groupId>
       <artifactId>msv</artifactId>
-      <version>2011.2-SNAPSHOT</version>
+      <version>2017.1-SNAPSHOT</version>
     </parent>
     <scm>
       <connection>scm:git:git@github.com:kohsuke/msv.git</connection>
@@ -49,18 +49,18 @@ EVEN IF SUN HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
       <url>http://github.com/kohsuke/msv</url> 
     </scm>
     <prerequisites>
-        <maven>2.2.1</maven>
+        <maven>2.2.1</maven><!-- tested with 3.3.9 -->
     </prerequisites>
     <dependencies>
         <dependency>
             <groupId>com.sun.msv.datatype.xsd</groupId>
             <artifactId>xsdlib</artifactId>
-            <version>2011.2-SNAPSHOT</version>
+            <version>2017.1-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>net.java.dev.msv</groupId>
             <artifactId>msv-testharness</artifactId>
-            <version>2011.2-SNAPSHOT</version>
+            <version>2017.1-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
         <!-- Note: Xerces only needed for TextUI; hence optional
@@ -74,7 +74,7 @@ EVEN IF SUN HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
         <dependency>
             <groupId>xerces</groupId>
             <artifactId>xercesImpl</artifactId>
-            <version>2.9.1</version>
+            <version>2.11.0</version>
             <!-- Note: Xerces only needed for TextUI; hence optional
         -->
             <optional>true</optional>
@@ -115,13 +115,14 @@ EVEN IF SUN HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <configuration>
-                    <source>1.5</source>
-                    <target>1.5</target>
+                    <!-- defined in the parent pom.xml -->
+					<source>${jdk.version}</source>
+					<target>${jdk.version}</target>
                     <encoding>UTF-8</encoding>
                     <maxmemory>1g</maxmemory>
                     <links>
-                        <!-- JDK 1.6 javadocs will remain longer -->
-                        <link>http://java.sun.com/javase/6/docs/api/</link>
+						<link>http://docs.oracle.com/javase/8/docs/api/</link>
+						<link>http://xerces.apache.org/xerces-j/apiDocs/</link>		
                     </links>
                 </configuration>
                 <executions>
@@ -131,6 +132,9 @@ EVEN IF SUN HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
                         <goals>
                             <goal>jar</goal>
                         </goals>
+                        <configuration>
+                            <additionalparam>${javadoc.opts}</additionalparam>
+                        </configuration>                        
                     </execution>
                 </executions>
             </plugin>
@@ -188,7 +192,7 @@ com.sun.msv.writer*
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-release-plugin</artifactId>
-                <version>2.0</version>
+                <version>2.5.3</version>
                 <configuration>
                     <mavenExecutorId>forked-path</mavenExecutorId>
                 </configuration>
@@ -256,7 +260,7 @@ com.sun.msv.writer*
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>
-                        <version>1.1</version>
+                        <version>1.6</version>
                         <executions>
                             <execution>
                                 <id>sign-artifacts</id>
@@ -270,5 +274,14 @@ com.sun.msv.writer*
                 </plugins>
             </build>
         </profile>
+        <profile>
+            <id>doclint-java8-disable</id>
+            <activation>
+                <jdk>[1.8,)</jdk>
+            </activation>
+            <properties>
+                <javadoc.opts>-Xdoclint:none</javadoc.opts>
+            </properties>
+        </profile>        
     </profiles>
 </project>

--- a/msv/src/main/java/com/sun/msv/grammar/BinaryExp.java
+++ b/msv/src/main/java/com/sun/msv/grammar/BinaryExp.java
@@ -2,10 +2,10 @@
  * @(#)$Id$
  *
  * Copyright 2001 Sun Microsystems, Inc. All Rights Reserved.
- * 
- * This software is the proprietary information of Sun Microsystems, Inc.  
+ *
+ * This software is the proprietary information of Sun Microsystems, Inc.
  * Use is subject to license terms.
- * 
+ *
  */
 package com.sun.msv.grammar;
 
@@ -13,41 +13,41 @@ import java.util.Iterator;
 
 /**
  * Base implementation for those expression which has two child expressions.
- * 
+ *
  * @author <a href="mailto:kohsuke.kawaguchi@eng.sun.com">Kohsuke KAWAGUCHI</a>
  */
 public abstract class BinaryExp extends Expression
 {
     // serialization support
-    private static final long serialVersionUID = 1;    
-    
+    private static final long serialVersionUID = 1;
+
     public final Expression exp1;
     public final Expression exp2;
-    
+
     public BinaryExp( Expression left, Expression right ) {
         super( left.hashCode()+right.hashCode() );
         this.exp1 = left;
         this.exp2 = right;
     }
-    
+
     protected final int calcHashCode() {
         return exp1.hashCode()+exp2.hashCode();
     }
-    
+
     public boolean equals( Object o ) {
         if( this.getClass()!=o.getClass() )        return false;
-        
+
         // every existing children are already unified.
         // therefore, == is enough. (don't need to call equals)
         BinaryExp rhs = (BinaryExp)o;
         return rhs.exp1 == exp1
             && rhs.exp2 == exp2;
     }
-    
+
     /**
      * returns all child expressions in one array.
-     * 
-     * This method is similar to the children method but it returns an array 
+     *
+     * This method is similar to the children method but it returns an array
      * that contains all children instead of an iterator object.
      */
     public Expression[] getChildren() {
@@ -58,7 +58,7 @@ public abstract class BinaryExp extends Expression
             cnt++;
             exp = ((BinaryExp)exp).exp1;
         }
-        
+
         Expression[] r = new Expression[cnt];
         exp=this;
         while( exp.getClass()==this.getClass() ) {
@@ -66,26 +66,26 @@ public abstract class BinaryExp extends Expression
             exp = ((BinaryExp)exp).exp1;
         }
         r[0] = exp;
-        
+
         return r;
     }
-    
+
     /**
      * iterates all child expressions.
-     * 
+     *
      * Since expressions are binarized, expressions like A|B|C is modeled as
      * A|(B|C).  This is may not be preferable for some applications.
-     * 
+     *
      * <P>
      * This method returns an iterator that iterates all children
      * (A,B, and C in this example)
      */
-    public Iterator<Object> children() {
+    public Iterator<Expression> children() {
         final Expression[] items = getChildren();
-        return new Iterator<Object>() {
+        return new Iterator<Expression>() {
             private int idx =0;
-            
-            public Object next() {
+
+            public Expression next() {
                 return items[idx++];
             }
             public boolean hasNext() { return idx!=items.length; }

--- a/msv/src/main/java/com/sun/msv/grammar/DataExp.java
+++ b/msv/src/main/java/com/sun/msv/grammar/DataExp.java
@@ -2,70 +2,70 @@
  * @(#)$Id$
  *
  * Copyright 2001 Sun Microsystems, Inc. All Rights Reserved.
- * 
- * This software is the proprietary information of Sun Microsystems, Inc.  
+ *
+ * This software is the proprietary information of Sun Microsystems, Inc.
  * Use is subject to license terms.
- * 
+ *
  */
 package com.sun.msv.grammar;
 
-import org.relaxng.datatype.Datatype;
-
 import com.sun.msv.datatype.xsd.XSDatatype;
 import com.sun.msv.util.StringPair;
+import org.relaxng.datatype.Datatype;
 
 /**
  * Expression that matchs characters of the particular {@link Datatype}.
- * 
+ *
  * @author <a href="mailto:kohsuke.kawaguchi@eng.sun.com">Kohsuke KAWAGUCHI</a>
  */
 public final class DataExp extends Expression implements DataOrValueExp {
-    
+
     /** datatype object that actually validates text. */
     public final Datatype dt;
     public Datatype getType() { return dt; }
-    
+
     /**
      * name of this datatype.
-     * 
+     *
      * The value of this field is not considered as significant.
      * When two TypedStringExps share the same Datatype object,
      * then they are unified even if they have different names.
      */
     public final StringPair name;
     public StringPair getName() { return name; }
-    
+
     /**
      * 'except' clause of RELAX NG.
      * If a token matches this pattern, then it should be rejected.
      */
     public final Expression except;
-    
+
     protected DataExp( Datatype dt, StringPair typeName, Expression except ) {
         super(dt.hashCode()+except.hashCode());
         this.dt=dt;
         this.name = typeName;
         this.except = except;
     }
-    
+
     protected final int calcHashCode() {
         return dt.hashCode()+except.hashCode();
     }
-    
+
     public boolean equals( Object o ) {
-        // Note that equals method of this class *can* be sloppy, 
+        if (o == null) return false;
+        // Note that equals method of this class *can* be sloppy,
         // since this class does not have a pattern as its child.
-        
+
         // Therefore datatype vocaburary does not necessarily provide
         // strict equals method.
         if(o.getClass()!=this.getClass())    return false;
-        
+
         DataExp rhs = (DataExp)o;
-        
+
         if( this.except != rhs.except )        return false;
         return rhs.dt.equals(dt);
     }
-    
+
     public Object visit( ExpressionVisitor visitor )                { return visitor.onData(this); }
     public Expression visit( ExpressionVisitorExpression visitor )    { return visitor.onData(this); }
     public boolean visit( ExpressionVisitorBoolean visitor )        { return visitor.onData(this); }
@@ -74,11 +74,11 @@ public final class DataExp extends Expression implements DataOrValueExp {
     protected boolean calcEpsilonReducibility() {
         XSDatatype xdt = (XSDatatype)dt;
         if(except==Expression.nullSet && xdt.isAlwaysValid())
-            // because for such datatype we return STRING_IGNORE from StringCareLevelCalculator 
+            // because for such datatype we return STRING_IGNORE from StringCareLevelCalculator
             return true;
         return false;
     }
-    
+
     // serialization support
-    private static final long serialVersionUID = 1;    
+    private static final long serialVersionUID = 1;
 }

--- a/msv/src/main/java/com/sun/msv/grammar/ValueExp.java
+++ b/msv/src/main/java/com/sun/msv/grammar/ValueExp.java
@@ -2,41 +2,40 @@
  * @(#)$Id$
  *
  * Copyright 2001 Sun Microsystems, Inc. All Rights Reserved.
- * 
- * This software is the proprietary information of Sun Microsystems, Inc.  
+ *
+ * This software is the proprietary information of Sun Microsystems, Inc.
  * Use is subject to license terms.
- * 
+ *
  */
 package com.sun.msv.grammar;
 
-import org.relaxng.datatype.Datatype;
-
 import com.sun.msv.util.StringPair;
+import org.relaxng.datatype.Datatype;
 
 /**
  * Expression that matchs a particular value of a {@link Datatype}.
- * 
+ *
  * @author <a href="mailto:kohsuke.kawaguchi@eng.sun.com">Kohsuke KAWAGUCHI</a>
  */
 public final class ValueExp extends Expression implements DataOrValueExp {
-    
+
     /** Datatype object that is used to test the equality. */
     public final Datatype dt;
     public Datatype getType() { return dt; }
 
     /** This expression matches this value only. */
     public final Object value;
-    
+
     /**
      * name of this datatype.
-     * 
+     *
      * The value of this field is not considered as significant.
      * When two TypedStringExps share the same Datatype object,
      * then they are unified even if they have different names.
      */
     public final StringPair name;
     public StringPair getName() { return name; }
-    
+
     protected ValueExp( Datatype dt, StringPair typeName, Object value ) {
         super(dt.hashCode()+dt.valueHashCode(value));
         this.dt=dt;
@@ -47,22 +46,23 @@ public final class ValueExp extends Expression implements DataOrValueExp {
     protected final int calcHashCode() {
         return dt.hashCode()+dt.valueHashCode(value);
     }
-    
+
     public boolean equals( Object o ) {
-        // Note that equals method of this class *can* be sloppy, 
+        if (o == null) return false;
+        // Note that equals method of this class *can* be sloppy,
         // since this class does not have a pattern as its child.
-        
+
         // Therefore datatype vocaburary does not necessarily provide
         // strict equals method.
         if(o.getClass()!=this.getClass())    return false;
-        
+
         ValueExp rhs = (ValueExp)o;
-        
+
         if(!rhs.dt.equals(dt))                return false;
-        
+
         return dt.sameValue(value,rhs.value);
     }
-    
+
     public Object visit( ExpressionVisitor visitor )                { return visitor.onValue(this); }
     public Expression visit( ExpressionVisitorExpression visitor )    { return visitor.onValue(this); }
     public boolean visit( ExpressionVisitorBoolean visitor )        { return visitor.onValue(this); }
@@ -71,7 +71,7 @@ public final class ValueExp extends Expression implements DataOrValueExp {
     protected boolean calcEpsilonReducibility() {
         return false;
     }
-    
+
     // serialization support
-    private static final long serialVersionUID = 1;    
+    private static final long serialVersionUID = 1;
 }

--- a/msv/src/main/java/com/sun/msv/grammar/util/ExpressionPrinter.java
+++ b/msv/src/main/java/com/sun/msv/grammar/util/ExpressionPrinter.java
@@ -2,10 +2,10 @@
  * @(#)$Id$
  *
  * Copyright 2001 Sun Microsystems, Inc. All Rights Reserved.
- * 
- * This software is the proprietary information of Sun Microsystems, Inc.  
+ *
+ * This software is the proprietary information of Sun Microsystems, Inc.
  * Use is subject to license terms.
- * 
+ *
  */
 package com.sun.msv.grammar.util;
 
@@ -29,35 +29,35 @@ import com.sun.msv.grammar.ValueExp;
 
 /**
  * creates a string representation of the expression.
- * 
+ *
  * useful for debug and dump.
- * 
+ *
  * @author <a href="mailto:kohsuke.kawaguchi@eng.sun.com">Kohsuke KAWAGUCHI</a>
  */
 public class ExpressionPrinter implements ExpressionVisitor {
-    
-    
+
+
     /** in this mode, reference to other expression is
      * one of the terminal symbol of stringnization.
-     * 
+     *
      * Suitable to dump the entire grammar
      */
     public final static int FRAGMENT = 0x001;
-    
+
     /** in this mode, element declaration is
      * one of the terminal symbol of stringnization.
-     * 
+     *
      * Suitable to dump the content model of element declarations.
      */
     public final static int CONTENTMODEL = 0x002;
 
-    
-    
+
+
     // singleton access
-    public static ExpressionPrinter fragmentInstance = new ExpressionPrinter(FRAGMENT);
-    public static ExpressionPrinter contentModelInstance = new ExpressionPrinter(CONTENTMODEL);
-    public static ExpressionPrinter smallestInstance = new ExpressionPrinter(CONTENTMODEL|FRAGMENT);
-    
+    public static final ExpressionPrinter fragmentInstance = new ExpressionPrinter(FRAGMENT);
+    public static final ExpressionPrinter contentModelInstance = new ExpressionPrinter(CONTENTMODEL);
+    public static final ExpressionPrinter smallestInstance = new ExpressionPrinter(CONTENTMODEL|FRAGMENT);
+
     public static String printFragment(Expression exp) {
         return (String)exp.visit(fragmentInstance);
     }
@@ -67,15 +67,15 @@ public class ExpressionPrinter implements ExpressionVisitor {
     public static String printSmallest(Expression exp) {
         return (String)exp.visit(smallestInstance);
     }
-    
-    
+
+
     /** this flag controls how expression will be stringnized */
     protected final int mode;
-    
+
     protected ExpressionPrinter( int mode ) { this.mode = mode; }
-    
+
     /** dumps all the contents of ReferenceContainer.
-     * 
+     *
      * this method is a useful piece to dump the entire grammar.
      */
     public String printRefContainer( ReferenceContainer cont ) {
@@ -87,34 +87,34 @@ public class ExpressionPrinter implements ExpressionVisitor {
         }
         return r;
     }
-    
+
     /** determines whether brackets should be used to represent the pattern */
     protected static boolean isComplex( Expression exp ) {
         return exp instanceof BinaryExp;
     }
-    
+
     protected String printBinary( BinaryExp exp, String op ) {
         String r;
-        
+
         if( exp.exp1.getClass()==exp.getClass() || !isComplex(exp.exp1) )
             r = (String)exp.exp1.visit(this);
         else
             r = "("+exp.exp1.visit(this)+")";
 
         r+=op;
-        
+
         if( !isComplex(exp.exp2) )
                 r+=exp.exp2.visit(this);
         else
                 r+="("+exp.exp2.visit(this)+")";
-        
+
         return r;
     }
-    
+
     public Object onAttribute( AttributeExp exp ) {
         return "@"+exp.nameClass.toString()+"<"+exp.exp.visit(this)+">";
     }
-    
+
     private Object optional( Expression exp ) {
         if( exp instanceof OneOrMoreExp ) {
             OneOrMoreExp ome = (OneOrMoreExp)exp;
@@ -125,11 +125,11 @@ public class ExpressionPrinter implements ExpressionVisitor {
             else                    return exp.visit(this)+"?";
         }
     }
-    
+
     public Object onChoice( ChoiceExp exp )     {
         if( exp.exp1==Expression.epsilon )    return optional(exp.exp2);
         if( exp.exp2==Expression.epsilon )    return optional(exp.exp1);
-            
+
         return printBinary(exp,"|");
     }
 
@@ -139,56 +139,56 @@ public class ExpressionPrinter implements ExpressionVisitor {
     public Object onInterleave( InterleaveExp exp ){
         return printBinary(exp,"^");
     }
-    
+
     public Object onElement( ElementExp exp ) {
         if( (mode&CONTENTMODEL)!=0 )
             return exp.getNameClass().toString();
         else
             return exp.getNameClass().toString()+"<"+exp.contentModel.visit(this)+">";
     }
-    
+
     public Object onOneOrMore( OneOrMoreExp exp ) {
         if( isComplex(exp.exp) )    return "("+exp.exp.visit(this)+")+";
         else                        return exp.exp.visit(this)+"+";
     }
-    
+
     public Object onMixed( MixedExp exp ) {
         return "mixed["+exp.exp.visit(this)+"]";
     }
-    
+
     public Object onList( ListExp exp ) {
         return "list["+exp.exp.visit(this)+"]";
     }
-    
+
     public Object onEpsilon() {
         return "#epsilon";
     }
-    
+
     public Object onNullSet() {
         return "#nullSet";
     }
-    
+
     public Object onAnyString() {
         return "<anyString>";
     }
-    
+
     public Object onSequence( SequenceExp exp )    {
         return printBinary(exp,",");
     }
-    
+
     public Object onData( DataExp exp ) {
         return "$"+exp.name.localName;
-    }    
+    }
 
     public Object onValue( ValueExp exp ) {
         return "$$"+exp.value;
-    }    
-    
+    }
+
     public Object onOther( OtherExp exp ) {
-        
+
         return exp.printName()+"["+exp.exp.visit(this)+"]";
     }
-        
+
     public Object onRef( ReferenceExp exp ) {
         if( (mode&FRAGMENT)!=0 )        return "{%"+exp.name+"}";
         else                            return "("+exp.exp.visit(this)+")";

--- a/pom.xml
+++ b/pom.xml
@@ -34,12 +34,12 @@ EVEN IF SUN HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
     <parent>
         <groupId>org.sonatype.oss</groupId>
         <artifactId>oss-parent</artifactId>
-        <version>5</version>
+        <version>9</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>net.java.dev.msv</groupId>
     <artifactId>msv</artifactId>
-    <version>2011.2-SNAPSHOT</version>
+    <version>2017.1-SNAPSHOT</version>
     <name>msv</name>
     <url>http://github.com/kohsuke/msv</url>
     <packaging>pom</packaging>
@@ -49,7 +49,7 @@ EVEN IF SUN HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
         <url>http://github.com/kohsuke/msv</url>
     </scm>
     <prerequisites>
-        <maven>3.0.3</maven>
+        <maven>3.0.3</maven><!-- tested with 3.3.9 -->
     </prerequisites>
     <distributionManagement>
         <site>
@@ -58,6 +58,7 @@ EVEN IF SUN HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
         </site>
     </distributionManagement>
     <properties>
+        <jdk.version>1.8</jdk.version>
         <surefire.fork.mode>once</surefire.fork.mode>
         <surefire.format>brief</surefire.format>
         <surefire.usefile>false</surefire.usefile>
@@ -100,7 +101,7 @@ EVEN IF SUN HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-source-plugin</artifactId>
-                        <version>2.1.2</version>
+                        <version>3.0.1</version>
                         <executions>
                             <execution>
                                 <id>attach-sources</id>
@@ -122,18 +123,19 @@ EVEN IF SUN HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
                             </execution>
                         </executions>
                         <configuration>
-                            <source>1.5</source>
-                            <target>1.5</target>
+                            <source>${jdk.version}</source>
+                            <target>${jdk.version}</target>
                             <encoding>UTF-8</encoding>
                             <links>
-                                <link>http://java.sun.com/javase/6/docs/api/</link>
+                                <link>http://docs.oracle.com/javase/8/docs/api/</link>
+                                <link>http://xerces.apache.org/xerces-j/apiDocs/</link>	
                             </links>
                         </configuration>
                     </plugin>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>
-                        <version>1.1</version>
+                        <version>1.6</version>
                         <executions>
                             <execution>
                                 <id>sign-artifacts</id>
@@ -164,7 +166,7 @@ EVEN IF SUN HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-compiler-plugin</artifactId>
-                        <version>2.3.2</version>
+                        <version>3.6.1</version>
                         <configuration>
                             <!-- not yet
                             <showDeprecation>true</showDeprecation>
@@ -184,7 +186,7 @@ EVEN IF SUN HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>2.7.1</version>
+                    <version>2.20</version>
                     <configuration>
                         <includes>
                             <include>**/*Test.java</include>
@@ -215,31 +217,31 @@ EVEN IF SUN HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-source-plugin</artifactId>
-                    <version>2.1.2</version>
+                    <version>2.4</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>2.3.2</version>
+                    <version>2.5.1</version>
                     <configuration>
-                        <source>1.5</source>
-                        <target>1.5</target>
+                        <source>${jdk.version}</source>
+                        <target>${jdk.version}</target>
                     </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>build-helper-maven-plugin</artifactId>
-                    <version>1.2</version>
+                    <version>3.0.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.felix</groupId>
                     <artifactId>maven-bundle-plugin</artifactId>
-                    <version>1.4.3</version>
+                    <version>3.3.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-release-plugin</artifactId>
-                    <version>2.1</version>
+                    <version>2.5.3</version>
                     <configuration>
                         <useReleaseProfile>true</useReleaseProfile>
                         <releaseProfiles>release</releaseProfiles>
@@ -250,35 +252,35 @@ EVEN IF SUN HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-javadoc-plugin</artifactId>
-                    <version>2.7</version>
+                    <version>2.10.4</version>
                     <configuration>
                         <attach>true</attach>
-                        <source>1.5</source>
+                        <source>${jdk.version}</source>
                         <quiet>true</quiet>
                         <bottom>MSV</bottom>
-                        <javadocVersion>1.5</javadocVersion>
+                        <javadocVersion>${jdk.version}</javadocVersion>
                         <encoding>UTF-8</encoding>
                     </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-jar-plugin</artifactId>
-                    <version>2.2</version>
+                    <version>3.0.2</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-resources-plugin</artifactId>
-                    <version>2.4.3</version>
+                    <version>3.0.2</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-assembly-plugin</artifactId>
-                    <version>2.2</version>
+                    <version>3.0.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-dependency-plugin</artifactId>
-                    <version>2.0</version>
+                    <version>3.0.1</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -288,7 +290,7 @@ EVEN IF SUN HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-site-plugin</artifactId>
-                    <version>3.0-beta-3</version>
+                    <version>3.6</version>
                 </plugin>
             </plugins>
         </pluginManagement>
@@ -296,12 +298,12 @@ EVEN IF SUN HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
             <extension>
                 <groupId>org.apache.maven.scm</groupId>
                 <artifactId>maven-scm-provider-gitexe</artifactId>
-                <version>1.3</version>
+                <version>1.9.5</version>
             </extension>
             <extension>
                 <groupId>org.apache.maven.scm</groupId>
                 <artifactId>maven-scm-manager-plexus</artifactId>
-                <version>1.3</version>
+                <version>1.9.5</version>
             </extension>
             <extension>
                 <groupId>org.kathrynhuxtable.maven.wagon</groupId>
@@ -315,13 +317,13 @@ EVEN IF SUN HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
             <dependency>
                 <groupId>junit</groupId>
                 <artifactId>junit</artifactId>
-                <version>4.8.2</version>
+                <version>4.12</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>xerces</groupId>
                 <artifactId>xercesImpl</artifactId>
-                <version>2.9.1</version>
+                <version>2.11.0</version>
             </dependency>
             <dependency>
                 <groupId>isorelax</groupId>
@@ -337,7 +339,7 @@ EVEN IF SUN HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
             <dependency>
                 <groupId>org.apache.ant</groupId>
                 <artifactId>ant</artifactId>
-                <version>1.7.1</version>
+                <version>1.10.1</version>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -346,17 +348,17 @@ EVEN IF SUN HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-report-plugin</artifactId>
-                <version>2.7.1</version>
+                <version>2.20</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-project-info-reports-plugin</artifactId>
-                <version>2.3.1</version>
+                <version>2.9</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.7</version>
+                <version>2.10.4</version>
                 <configuration>
                     <attach>true</attach>
                     <quiet>true</quiet>

--- a/relames/pom.xml
+++ b/relames/pom.xml
@@ -8,7 +8,7 @@
   <parent>
       <groupId>net.java.dev.msv</groupId>
       <artifactId>msv</artifactId>
-      <version>2011.2-SNAPSHOT</version>
+      <version>2017.1-SNAPSHOT</version>
   </parent>
     <scm>
       <connection>scm:git:git@github.com:kohsuke/msv.git</connection>

--- a/rngconverter/pom.xml
+++ b/rngconverter/pom.xml
@@ -34,12 +34,12 @@ EVEN IF SUN HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
     <modelVersion>4.0.0</modelVersion>
     <groupId>net.java.dev.msv</groupId>
     <artifactId>msv-rngconverter</artifactId>
-    <version>2011.2-SNAPSHOT</version>
+    <version>2017.1-SNAPSHOT</version>
     <name>MSV RNG Converter</name>
     <parent>
       <groupId>net.java.dev.msv</groupId>
       <artifactId>msv</artifactId>
-      <version>2011.2-SNAPSHOT</version>
+      <version>2017.1-SNAPSHOT</version>
     </parent>
     <scm>
       <connection>scm:git:git@github.com:kohsuke/msv.git</connection>
@@ -50,7 +50,7 @@ EVEN IF SUN HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>1.4</version>
+                <version>3.0.0</version>
                 <executions>
                     <execution>
                         <phase>package</phase>
@@ -96,7 +96,7 @@ EVEN IF SUN HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
         <dependency>
             <groupId>xerces</groupId>
             <artifactId>xercesImpl</artifactId>
-            <version>2.9.1</version>
+            <version>2.11.0</version>
         </dependency>
         <dependency>
             <groupId>xml-resolver</groupId>

--- a/testharness/pom.xml
+++ b/testharness/pom.xml
@@ -3,12 +3,12 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>net.java.dev.msv</groupId>
   <artifactId>msv-testharness</artifactId>
-  <version>2011.2-SNAPSHOT</version>
+  <version>2017.1-SNAPSHOT</version>
   <name>MSV Test Harness</name>
   <parent>
       <groupId>net.java.dev.msv</groupId>
       <artifactId>msv</artifactId>
-      <version>2011.2-SNAPSHOT</version>
+      <version>2017.1-SNAPSHOT</version>
   </parent>
 
   <scm>

--- a/xsdlib/pom.xml
+++ b/xsdlib/pom.xml
@@ -34,15 +34,15 @@ EVEN IF SUN HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.sun.msv.datatype.xsd</groupId>
     <artifactId>xsdlib</artifactId>
-    <version>2011.2-SNAPSHOT</version>
+    <version>2017.1-SNAPSHOT</version>
     <name>MSV XML Schema Datatype Library</name>
     <description>XML Schema datatypes library</description>
     <url>http://github.com/kohsuke/msv</url>
-    <packaging>bundle</packaging>
+    <packaging>jar</packaging><!-- OSGi bundle is missing activator interface -->
     <parent>
       <groupId>net.java.dev.msv</groupId>
       <artifactId>msv</artifactId>
-      <version>2011.2-SNAPSHOT</version>
+      <version>2017.1-SNAPSHOT</version>
     </parent>
     <scm>
       <connection>scm:git:git@github.com:kohsuke/msv.git</connection>
@@ -78,7 +78,7 @@ EVEN IF SUN HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
         <dependency>
             <groupId>xerces</groupId>
             <artifactId>xercesImpl</artifactId>
-            <version>2.9.1</version>
+            <version>2.11.0</version>
             <optional>true</optional>
         </dependency>
         <dependency>
@@ -94,8 +94,8 @@ EVEN IF SUN HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
         </dependency>
         <dependency>
             <groupId>org.jdom</groupId>
-            <artifactId>jdom</artifactId>
-            <version>1.1</version>
+            <artifactId>jdom2</artifactId>
+            <version>2.0.6</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -138,13 +138,13 @@ EVEN IF SUN HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <configuration>
-                    <source>1.5</source>
-                    <target>1.5</target>
+					<source>${jdk.version}</source>
+					<target>${jdk.version}</target>
                     <encoding>UTF-8</encoding>
                     <maxmemory>1g</maxmemory>
                     <links>
-                        <!-- JDK 1.6 javadocs will remain longer -->
-                        <link>http://java.sun.com/javase/6/docs/api/</link>
+						<link>http://docs.oracle.com/javase/8/docs/api/</link>
+						<link>http://xerces.apache.org/xerces-j/apiDocs/</link>	
                     </links>
                 </configuration>
                 <executions>
@@ -154,6 +154,9 @@ EVEN IF SUN HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
                         <goals>
                             <goal>jar</goal>
                         </goals>
+                        <configuration>
+                            <additionalparam>${javadoc.opts}</additionalparam>
+                        </configuration>                          
                     </execution>
                 </executions>
             </plugin>
@@ -190,7 +193,7 @@ com.sun.msv.datatype.xsd*
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-release-plugin</artifactId>
-                <version>2.0</version>
+                <version>2.5.3</version>
                 <configuration>
                     <mavenExecutorId>forked-path</mavenExecutorId>
                 </configuration>
@@ -265,7 +268,7 @@ com.sun.msv.datatype.xsd*
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>
-                        <version>1.1</version>
+                        <version>1.6</version>
                         <executions>
                             <execution>
                                 <id>sign-artifacts</id>
@@ -279,5 +282,14 @@ com.sun.msv.datatype.xsd*
                 </plugins>
             </build>
         </profile>
+        <profile>
+            <id>doclint-java8-disable</id>
+            <activation>
+                <jdk>[1.8,)</jdk>
+            </activation>
+            <properties>
+                <javadoc.opts>-Xdoclint:none</javadoc.opts>
+            </properties>
+        </profile>        
     </profiles>
 </project>

--- a/xsdlib/src/test/java/com/sun/msv/datatype/xsd/conformance/DataTypeTester.java
+++ b/xsdlib/src/test/java/com/sun/msv/datatype/xsd/conformance/DataTypeTester.java
@@ -2,10 +2,10 @@
  * @(#)$Id$
  *
  * Copyright 2001 Sun Microsystems, Inc. All Rights Reserved.
- * 
- * This software is the proprietary information of Sun Microsystems, Inc.  
+ *
+ * This software is the proprietary information of Sun Microsystems, Inc.
  * Use is subject to license terms.
- * 
+ *
  */
 /*
  * $Id$
@@ -16,26 +16,25 @@ import com.sun.msv.datatype.xsd.DatatypeFactory;
 import com.sun.msv.datatype.xsd.TypeIncubator;
 import com.sun.msv.datatype.xsd.XSDatatype;
 import com.sun.msv.datatype.xsd.XSDatatypeImpl;
-import org.jdom.Element;
-import org.relaxng.datatype.DatatypeException;
-
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.PrintStream;
 import java.util.List;
+import org.jdom2.Element;
+import org.relaxng.datatype.DatatypeException;
 
 /**
  * tests DataType.verify method with various types and various lexical values.
- * 
+ *
  * @author <a href="mailto:kohsuke.kawaguchi@eng.sun.com">Kohsuke KAWAGUCHI</a>
  */
 public class DataTypeTester
 {
     /** progress indication will be sent to this object */
     private final PrintStream out;
-    
+
     /** error will be passed to this object */
     private final ErrorReceiver err;
 
@@ -44,12 +43,12 @@ public class DataTypeTester
         this.out = out;
         this.err = err;
     }
-    
+
     public void run( Element testCase )
         throws Exception
     {
         out.println( testCase.getAttributeValue("name") );
-        
+
         String[] values;
         {// read values
             List lst = testCase.getChildren("value");
@@ -57,31 +56,31 @@ public class DataTypeTester
             for( int i=0; i<values.length; i++ )
                 values[i] = ((Element)lst.get(i)).getText();
         }
-        
+
         String[] wrongValues;
         {// read wrongValues, which is always wrong with any types tested
             Element wrongs = testCase.getChild("wrongs");
             if(wrongs==null)    throw new Exception("no <wrongs>");
-            
+
             List lst = wrongs.getChildren("value");
             wrongValues = new String[lst.size()];
             for( int i=0; i<wrongValues.length; i++ )
                 wrongValues[i] = ((Element)lst.get(i)).getText();
         }
-        
+
         // parses a test pattern, which basically enumerates
         // possible test pattern and its expected result
         Element facetElement = testCase.getChild("facets");
         TestPattern pattern =
             TestPatternGenerator.parse(
                 (Element)facetElement.getChildren().get(0));
-        
+
         {
             List lst = testCase.getChildren("answer");
             for( int i=0; i<lst.size(); i++ )
             {
                 Element item = (Element)lst.get(i);
-                
+
                 // perform test as a single type
                 XSDatatypeImpl t = (XSDatatypeImpl)DatatypeFactory.getTypeByName(item.getAttributeValue("for"));
                 if(t==null)
@@ -108,7 +107,7 @@ public class DataTypeTester
             }
         }
     }
-    
+
     /**
      * tests one datatype
      *
@@ -141,19 +140,19 @@ public class DataTypeTester
         long startTime = System.currentTimeMillis();
         out.println("  testing " + baseType.getName() +
             " (total "+pattern.totalCases()+" patterns)" );
-        
+
         pattern.reset();
-        
+
         long cnt=0;
-        
+
         while(true)
         {
             if((cnt%500)==0 && cnt!=0 )    out.print("\r"+cnt+"    ");
-            
+
             if( !pattern.hasMore() )    break;
             final TypeIncubator ti = new TypeIncubator(baseType);
             String answer;
-            
+
             try
             {
                 answer = TestPatternGenerator.merge( baseAnswer, pattern.get(ti), true );
@@ -162,8 +161,8 @@ public class DataTypeTester
             {// ignore this error
                 pattern.next();
                 continue;
-            } 
-            
+            }
+
             // derive a type with test facets.
             XSDatatype typeObj=null;
             try
@@ -178,18 +177,18 @@ public class DataTypeTester
             {// make sure that the serialization works.
                 ByteArrayOutputStream bos = new ByteArrayOutputStream();
                 ObjectOutputStream oos = new ObjectOutputStream(bos);
-        
+
                 // serialize it
                 oos.writeObject( typeObj );
                 oos.flush();
-                
+
                 // obtain byte array (just in case)
                 ObjectInputStream ois = new ObjectInputStream(
                     new ByteArrayInputStream(bos.toByteArray()));
                 typeObj = (XSDatatype)ois.readObject();
                 ois.close();
             }
-            
+
             if(typeObj!=null)
             {
                 if( answer.length()!=values.length )
@@ -203,12 +202,12 @@ public class DataTypeTester
                 {
                     boolean v = typeObj.isValid(values[i],DummyContextProvider.theInstance);
                     boolean d;
-                    
+
                     boolean roundTripError = false;
-                    
+
                     Object o = typeObj.createValue(
                         values[i],DummyContextProvider.theInstance);
-                    
+
                     try {
                         if(o!=null) {
                             // should be able to convert it back.
@@ -225,13 +224,13 @@ public class DataTypeTester
                     }
 
                     Object jo = typeObj.createJavaObject( values[i], DummyContextProvider.theInstance );
-                    
+
                     if( jo!=null ) {
                         if( !typeObj.getJavaObjectType().isAssignableFrom(jo.getClass()) ) {
                             System.out.println("type error");
                             roundTripError = true;
                         }
-                        
+
                         String s = typeObj.serializeJavaObject( jo,
                                         DummyContextProvider.theInstance );
                         if(s==null) {
@@ -245,30 +244,30 @@ public class DataTypeTester
                             }
                         }
                     }
-                    
+
                     try {
                         typeObj.checkValid(values[i],DummyContextProvider.theInstance);
                         d = true;
                     } catch( DatatypeException de ) {
                         d = false;
                     }
-                    
+
                     // if convertToValueObject and verify method differs,
                     // it's always an error.
                     // roundTripError is always an error.
                     if(!roundTripError && (o!=null)==v && (jo!=null)==v ) {
-                        
+
                         if(v && d && answer.charAt(i)=='o')
                             continue;    // as predicted
                         if(!v && !d && answer.charAt(i)=='.')
                             continue;    // as predicted
-                    
+
                         if(completenessOnly && answer.charAt(i)=='.' && v==d )
                             continue;    // do not report error if
                                         // the validator accepts things that
                                         // may not be accepted.
                     }
-                    
+
                     // dump error messages
                     if( !err.report( new UnexpectedResultException(
                             typeObj, baseType.getName(),
@@ -283,7 +282,7 @@ public class DataTypeTester
                 // test each wrong values and makes sure that they are rejected.
                 for( int i=0; i<wrongs.length; i++ ) {
                     boolean err = false;
-                    
+
                     err = typeObj.isValid(wrongs[i],DummyContextProvider.theInstance);
                     try {
                         typeObj.checkValid(wrongs[i],DummyContextProvider.theInstance);
@@ -291,10 +290,10 @@ public class DataTypeTester
                     } catch (DatatypeException de) {
                         ;    // it should throw an exception
                     }
-                    
+
                     if( typeObj.createJavaObject(wrongs[i],DummyContextProvider.theInstance)!=null )
                         err = true;
-                    
+
                     if( err ) {
                         if( !this.err.report( new UnexpectedResultException(
                             typeObj, baseType.getName(),
@@ -306,16 +305,16 @@ public class DataTypeTester
                     }
                 }
             }
-            
+
             cnt++;
             pattern.next();
         }
-        
+
         out.println();
         // test done
         out.println("  " + cnt + " cases tested ("+(System.currentTimeMillis()-startTime)+"ms)");
     }
-    
+
     public static final String[] builtinTypesList =
     new String[]{
         "string",

--- a/xsdlib/src/test/java/com/sun/msv/datatype/xsd/conformance/TestDriver.java
+++ b/xsdlib/src/test/java/com/sun/msv/datatype/xsd/conformance/TestDriver.java
@@ -2,27 +2,26 @@
  * @(#)$Id$
  *
  * Copyright 2001 Sun Microsystems, Inc. All Rights Reserved.
- * 
- * This software is the proprietary information of Sun Microsystems, Inc.  
+ *
+ * This software is the proprietary information of Sun Microsystems, Inc.
  * Use is subject to license terms.
- * 
+ *
  */
 package com.sun.msv.datatype.xsd.conformance;
 
 import com.sun.msv.datatype.xsd.TypeIncubator;
 import com.sun.msv.datatype.xsd.XSDatatype;
-import org.jdom.Document;
-import org.jdom.Element;
-import org.jdom.JDOMException;
-import org.jdom.input.SAXBuilder;
+import java.util.Iterator;
+import org.jdom2.Document;
+import org.jdom2.Element;
+import org.jdom2.JDOMException;
+import org.jdom2.input.SAXBuilder;
 import org.relaxng.datatype.Datatype;
 import org.relaxng.datatype.DatatypeException;
 
-import java.util.Iterator;
-
 /**
  * conformance test runner.
- * 
+ *
  * @author <a href="mailto:kohsuke.kawaguchi@eng.sun.com">Kohsuke KAWAGUCHI</a>
  */
 class TestDriver implements ErrorReceiver
@@ -46,7 +45,7 @@ class TestDriver implements ErrorReceiver
             System.err.println(e.getMessage());
         }
     }
-    
+
     private DatatypeException getDiagnosis( Datatype dt, String literal ) {
         try {
             dt.checkValid(literal,DummyContextProvider.theInstance);
@@ -55,11 +54,11 @@ class TestDriver implements ErrorReceiver
             return de;
         }
     }
-    
+
     public boolean report( UnexpectedResultException exp ) {
         Object o = exp.type.createValue(exp.testInstance,DummyContextProvider.theInstance);
         Object jo = exp.type.createJavaObject(exp.testInstance,DummyContextProvider.theInstance);
-        
+
         System.out.println("************* error *************");
         System.out.println("type name            : "+exp.baseTypeName);
         System.out.println("tested instance      : \""+exp.testInstance+"\"");
@@ -70,14 +69,14 @@ class TestDriver implements ErrorReceiver
         System.out.println("diagnose method      : "+(getDiagnosis(exp.type,exp.testInstance)==null) );
         System.out.println("JavaObjectType       : "+(jo!=null?jo.getClass().toString():"N/A") );
         System.out.println("expected Type        : "+exp.type.getJavaObjectType() );
-        
+
         if(jo!=null)
             try {
                 System.out.println("serializeJavaObject  : "+exp.type.serializeJavaObject(jo,DummyContextProvider.theInstance) );
             } catch( Exception e ) {
                 System.out.println("serializeJavaObject  : "+e );
             }
-        
+
         if(o!=null)
             try {
                 System.out.println("convertToLexical     : "+exp.type.convertToLexicalValue(o,DummyContextProvider.theInstance));
@@ -85,22 +84,22 @@ class TestDriver implements ErrorReceiver
                 System.out.println("convertToLexical     : "+e);
                 e.printStackTrace();
             }
-        
+
         if( exp.incubator.isEmpty() )
             System.out.println("facets: none");
         else
             exp.incubator.dump(System.out);
 
         DatatypeException err = getDiagnosis( exp.type, exp.testInstance );
-        
+
         if( err!=null && err.getMessage()!=null )
             System.out.println("diagnosis: " + err.getMessage() );
         else
             System.out.println("diagnosis: N/A");
-        
+
         // do it again (for trace purpose)
         exp.type.isValid(exp.testInstance,DummyContextProvider.theInstance);
-        
+
         return false;
     }
 
@@ -110,14 +109,14 @@ class TestDriver implements ErrorReceiver
         System.err.println("test case error");
         facets.dump(System.err);
         System.err.println();
-        
+
         try
         {// do it again (for debug)
             baseType.derive("anonymous",facets);
         }
         catch( Exception ee ) { ; }
 */
-        
+
         return false;
     }
 }

--- a/xsdlib/src/test/java/com/sun/msv/datatype/xsd/conformance/TestPatternGenerator.java
+++ b/xsdlib/src/test/java/com/sun/msv/datatype/xsd/conformance/TestPatternGenerator.java
@@ -2,20 +2,19 @@
  * @(#)$Id$
  *
  * Copyright 2001 Sun Microsystems, Inc. All Rights Reserved.
- * 
- * This software is the proprietary information of Sun Microsystems, Inc.  
+ *
+ * This software is the proprietary information of Sun Microsystems, Inc.
  * Use is subject to license terms.
- * 
+ *
  */
 package com.sun.msv.datatype.xsd.conformance;
 
-import org.jdom.Element;
-
 import java.util.List;
+import org.jdom2.Element;
 
 /**
  * parses XML representation of test pattern.
- * 
+ *
  * @author <a href="mailto:kohsuke.kawaguchi@eng.sun.com">Kohsuke KAWAGUCHI</a>
  */
 class TestPatternGenerator
@@ -37,14 +36,14 @@ class TestPatternGenerator
             TestPattern[] children = new TestPattern[lst.size()];
             for( int i=0; i<lst.size(); i++ )
                 children[i] = parse( (Element)lst.get(i) );
-            
+
             if( tagName.equals("combination") )
             {
                 boolean mode = true;    // default is 'AND'
                 if( patternElement.getAttribute("mode")!=null
                 &&  patternElement.getAttributeValue("mode").equals("or") )
                     mode = false;
-                
+
                 return new FullCombinationPattern(children,mode);
             }
             else
@@ -59,10 +58,10 @@ class TestPatternGenerator
                 patternElement.getAttributeValue("value"),
                 trimAnswer(patternElement.getAttributeValue("answer")) );
         }
-        
+
         throw new Exception("unknown pattern:"+tagName);
     }
-    
+
     public static String trimAnswer( String answer )
     {
         String r="";
@@ -72,7 +71,7 @@ class TestPatternGenerator
             final char ch = answer.charAt(i);
             if(ch=='o' || ch=='.')    r+=ch;
         }
-        
+
         return r;
     }
 
@@ -83,7 +82,7 @@ class TestPatternGenerator
         if(a2==null)    return a1;
         if( a1.length()!=a2.length() )
             throw new Error("assertion: lengths of the answers are different");
-        
+
         final int len = a1.length();
         String newAnswer ="";
         for( int i=0; i<len; i++ )
@@ -94,7 +93,7 @@ class TestPatternGenerator
             else
                 newAnswer += ".";
         }
-        
+
         return newAnswer;
     }
 }


### PR DESCRIPTION
https://msv.java.net is finally down.
You are working on the most advanced sources of MSV but on a very low version number (ie. 2011.2-SNAPSHOT). The problem with the version number, there are Java artefacts able to be downloaded via Maven with version 2013.6.1, which lack many fixes and enhancement your branch did.
I double checked and there are no further fixes on their final artefact 2013.6.2-SNAPSHOT and took the opportunity to update all dependent 3rd party libraries including JDK 5 to 8 - as older JDK versions are hard to get these days and not necessarily secure - and switched to 2017.1-SNAPSHOT.
