### PR TITLE
adding calendar field validation to CalendarParser#parse

### DIFF
--- a/xsdlib/src/main/java/com/sun/msv/datatype/xsd/datetime/CalendarParser.java
+++ b/xsdlib/src/main/java/com/sun/msv/datatype/xsd/datetime/CalendarParser.java
@@ -2,10 +2,10 @@
  * @(#)$Id$
  *
  * Copyright 2001 Sun Microsystems, Inc. All Rights Reserved.
- * 
- * This software is the proprietary information of Sun Microsystems, Inc.  
+ *
+ * This software is the proprietary information of Sun Microsystems, Inc.
  * Use is subject to license terms.
- * 
+ *
  */
 package com.sun.msv.datatype.xsd.datetime;
 
@@ -14,7 +14,7 @@ import java.util.GregorianCalendar;
 
 /**
  * Parses XML Schema date/time related types into {@link java.util.Calendar}.
- * 
+ *
  * @author
  *     Kohsuke Kawaguchi (kohsuke.kawaguchi@sun.com)
  */
@@ -22,26 +22,34 @@ public final class CalendarParser extends AbstractCalendarParser {
     public static GregorianCalendar parse( String format, String value ) throws IllegalArgumentException {
         CalendarParser parser = new CalendarParser(format,value);
         parser.parse();
-        return parser.cal;
+
+        GregorianCalendar cal = parser.cal;
+
+        // fail on invalid dates
+        cal.setLenient(false);
+        cal.getTimeInMillis();
+
+        return cal;
     }
-    
+
     // this version is faster than new GregorianCalendar()
     // which involves in setting the current time.
     private final GregorianCalendar cal = new GregorianCalendar(0,0,0);
-    
+
     private CalendarParser( String format, String value ) {
         super(format,value);
+
         // erase all the fields to remove any trace of the current time.
         cal.clear(Calendar.YEAR);
         cal.clear(Calendar.MONTH);
         cal.clear(Calendar.DAY_OF_MONTH);
     }
-    
+
     protected void parseFractionSeconds() {
         cal.set(Calendar.MILLISECOND,parseInt(1,3));
         skipDigits();
     }
-    
+
     protected void setTimeZone( java.util.TimeZone tz ) {
         cal.setTimeZone(tz);
     }


### PR DESCRIPTION
Prevents invalid dates (e.g. 2018-50-01) passing the schema validation.